### PR TITLE
Working Alpine build

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -19,7 +19,9 @@ RUN apk add --no-cache \
 		erlang \
 		erlang-os-mon \
 		erlang-public-key \
+		erlang-sasl \
 		erlang-ssl \
+		erlang-syntax-tools \
 		erlang-xmerl
 
 # get logs to stdout (thanks @dumbbell for pushing this upstream! :D)

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -41,7 +41,7 @@ RUN set -ex; \
 	apk add --no-cache --virtual .build-deps \
 		ca-certificates \
 		gnupg \
-		openssl \
+		libressl \
 		tar \
 		xz \
 	; \


### PR DESCRIPTION
Hoping to get rabbitmq on Alpine, I came across [this issue](https://github.com/docker-library/rabbitmq/issues/128). I forked this branch and got the same error. Turns out the erlang-sasl dep needs to be included. But after including it, I ran into another error. This time more explicit, saying syntax-tools is missing. With those two deps added, rabbitmq was happy!

Also, starting with 3.5, Alpine ships with libressl instead of openssl. I went ahead and updated the Dockerfile with that as well, because having both libs may cause issues down the road.

Initial testing shows no issues so far.